### PR TITLE
Add a `hide-errors` prop to the `LForm` component

### DIFF
--- a/src/components/LForm/LForm.tsx
+++ b/src/components/LForm/LForm.tsx
@@ -1,22 +1,21 @@
 import { defineComponent } from 'vue';
 import { useRender } from '@/utils/render';
-import { createForm } from '@/composables/form';
-
-// Types
-import type { PropType } from 'vue';
+import {
+  createForm,
+  makeFormEmits,
+  makeFormProps,
+  SUBMIT,
+  SUBMIT_PROP,
+} from '@/composables/form';
 
 export const LForm = defineComponent({
   name: 'LForm',
   inheritAttrs: false,
   props: {
-    // onSubmit is declared as a hack to be able to detect
-    // when the 'submit' listener is defined
-    // eslint-disable-next-line vue/require-default-prop
-    onSubmit: Function as PropType<(event: Event) => void>,
+    ...makeFormProps(),
   },
   emits: {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    submit: (event: Event) => true,
+    ...makeFormEmits(),
   },
   setup(props, { attrs, emit, slots }) {
     const form = createForm();
@@ -24,8 +23,8 @@ export const LForm = defineComponent({
     const onSubmit = (event: Event) => {
       event.preventDefault();
       if (form.valid.value) {
-        if (props.onSubmit) {
-          emit('submit', event);
+        if (props[SUBMIT_PROP]) {
+          emit(SUBMIT, event);
         } else {
           ((event as SubmitEvent).target as HTMLFormElement).submit();
         }

--- a/src/components/LForm/LForm.tsx
+++ b/src/components/LForm/LForm.tsx
@@ -18,7 +18,7 @@ export const LForm = defineComponent({
     ...makeFormEmits(),
   },
   setup(props, { attrs, emit, slots }) {
-    const form = createForm();
+    const form = createForm(props);
 
     const onSubmit = (event: Event) => {
       event.preventDefault();

--- a/src/components/LInput/LInput.tsx
+++ b/src/components/LInput/LInput.tsx
@@ -1,4 +1,4 @@
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 import {
   useValidation,
   makeValidationEmits,
@@ -11,10 +11,6 @@ export const LInput = defineComponent({
   name: 'LInput',
   inheritAttrs: false,
   props: {
-    hideErrors: {
-      type: Boolean,
-      default: () => false,
-    },
     ...makeValidationProps<string>(),
   },
   emits: {
@@ -22,6 +18,8 @@ export const LInput = defineComponent({
   },
   setup(props, { attrs, emit }) {
     const validation = useValidation<string>(props);
+
+    const showErrors = computed(() => !validation.hideErrors && validation.error.value);
 
     const onInput = (event: Event) => {
       emit(UPDATE_MODEL_VALUE, (event.target as HTMLInputElement).value);
@@ -35,11 +33,7 @@ export const LInput = defineComponent({
           onBlur={validation.startValidating}
           { ...attrs }
         />
-        {
-          !props.hideErrors
-          && validation.error.value
-          && <p>{ validation.error.value }</p>
-        }
+        { showErrors.value && <p>{ validation.error.value }</p> }
       </>
     ));
 

--- a/src/components/LInput/LInput.tsx
+++ b/src/components/LInput/LInput.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent } from 'vue';
+import { defineComponent } from 'vue';
 import {
   useValidation,
   makeValidationEmits,
@@ -19,8 +19,6 @@ export const LInput = defineComponent({
   setup(props, { attrs, emit }) {
     const validation = useValidation<string>(props);
 
-    const showErrors = computed(() => !validation.hideErrors && validation.error.value);
-
     const onInput = (event: Event) => {
       emit(UPDATE_MODEL_VALUE, (event.target as HTMLInputElement).value);
     };
@@ -33,7 +31,7 @@ export const LInput = defineComponent({
           onBlur={validation.startValidating}
           { ...attrs }
         />
-        { showErrors.value && <p>{ validation.error.value }</p> }
+        { validation.renderError.value && <p>{ validation.error.value }</p> }
       </>
     ));
 

--- a/src/composables/form.ts
+++ b/src/composables/form.ts
@@ -3,7 +3,12 @@ import {
 } from 'vue';
 
 // Types
-import type { ComputedRef, InjectionKey, Ref } from 'vue';
+import type {
+  ComputedRef, InjectionKey, PropType, Ref,
+} from 'vue';
+
+export const SUBMIT = 'submit';
+export const SUBMIT_PROP = 'onSubmit';
 
 type IdType = number;
 
@@ -24,6 +29,17 @@ export interface FormProvide {
 }
 
 export const FormKey: InjectionKey<FormProvide> = Symbol.for('loveform:form');
+
+export const makeFormProps = () => ({
+  // onSubmit is declared as a hack to be able to detect
+  // when the 'submit' listener is defined
+  onSubmit: Function as PropType<(event: Event) => void>,
+});
+
+export const makeFormEmits = () => ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  [SUBMIT]: (event: Event) => true,
+});
 
 export const createForm = () => {
   const items = shallowRef<Array<FormField>>([]);

--- a/src/composables/form.ts
+++ b/src/composables/form.ts
@@ -13,8 +13,13 @@ export const SUBMIT_PROP = 'onSubmit';
 type IdType = number;
 
 interface FormField {
-  id: IdType
-  valid: Ref<boolean>
+  id: IdType,
+  valid: Ref<boolean>,
+}
+
+export interface FormProps {
+  onSubmit?: (event: Event) => void,
+  hideErrors: boolean,
 }
 
 export interface FormProvide {
@@ -25,6 +30,7 @@ export interface FormProvide {
   unregister: (
     id: IdType,
   ) => void,
+  hideErrors: boolean,
   valid: ComputedRef<boolean>,
 }
 
@@ -34,6 +40,10 @@ export const makeFormProps = () => ({
   // onSubmit is declared as a hack to be able to detect
   // when the 'submit' listener is defined
   onSubmit: Function as PropType<(event: Event) => void>,
+  hideErrors: {
+    type: Boolean,
+    default: () => false,
+  },
 });
 
 export const makeFormEmits = () => ({
@@ -41,7 +51,7 @@ export const makeFormEmits = () => ({
   [SUBMIT]: (event: Event) => true,
 });
 
-export const createForm = () => {
+export const createForm = (props: FormProps) => {
   const items = shallowRef<Array<FormField>>([]);
 
   const publicValid = computed(() => {
@@ -61,6 +71,7 @@ export const createForm = () => {
     unregister: (id: IdType) => {
       items.value = items.value.filter((item) => item.id !== id);
     },
+    hideErrors: props.hideErrors,
     valid: publicValid,
   });
 

--- a/src/composables/validation.ts
+++ b/src/composables/validation.ts
@@ -1,5 +1,5 @@
 import {
-  computed, ComputedRef, onBeforeMount, onBeforeUnmount, ref, watch,
+  computed, onBeforeMount, onBeforeUnmount, ref, watch,
 } from 'vue';
 import { useForm } from '@/composables/form';
 import { getUniqueId } from '@/utils/uniqueId';
@@ -8,10 +8,6 @@ import { getUniqueId } from '@/utils/uniqueId';
 import type { PropType } from 'vue';
 
 export const UPDATE_MODEL_VALUE = 'update:modelValue';
-
-export interface FieldProvide {
-  valid: ComputedRef<boolean>,
-}
 
 export type Validation<T> = (value: T) => true | string;
 

--- a/src/composables/validation.ts
+++ b/src/composables/validation.ts
@@ -64,6 +64,8 @@ export const useValidation = <T>(props: ValidationProps<T>) => {
     }
   };
 
+  const renderError = computed(() => !hideErrors && error.value);
+
   const publicValid = computed(() => {
     if (!validating.value) {
       startValidating();
@@ -86,7 +88,7 @@ export const useValidation = <T>(props: ValidationProps<T>) => {
     startValidating,
     valid: publicValid,
     privateValid,
-    hideErrors,
+    renderError,
     error,
   };
 };

--- a/src/composables/validation.ts
+++ b/src/composables/validation.ts
@@ -14,6 +14,7 @@ export type Validation<T> = (value: T) => true | string;
 export interface ValidationProps<T> {
   modelValue: T,
   validations: Array<Validation<T>>,
+  hideErrors: boolean,
 }
 
 export const makeValidationProps = <T>() => ({
@@ -24,6 +25,10 @@ export const makeValidationProps = <T>() => ({
   validations: {
     type: Array as PropType<Array<Validation<T>>>,
     default: () => ([]),
+  },
+  hideErrors: {
+    type: Boolean,
+    default: () => false,
   },
 });
 
@@ -39,6 +44,8 @@ export const useValidation = <T>(props: ValidationProps<T>) => {
   const validating = ref(false);
   const error = ref('');
   const privateValid = computed(() => !error.value.trim());
+
+  const hideErrors = form?.hideErrors || props.hideErrors;
 
   const startValidating = () => {
     validating.value = true;
@@ -79,6 +86,7 @@ export const useValidation = <T>(props: ValidationProps<T>) => {
     startValidating,
     valid: publicValid,
     privateValid,
+    hideErrors,
     error,
   };
 };


### PR DESCRIPTION
## Description

Until now, errors could be hidden individually on each input component, but not as a whole for a specific form. Now there is a `hide-errors` prop for inputs and forms that hides the errors shown.

## Requirements

None.

## Additional changes

None.
