### PR TITLE
Add a `LTextarea` component

### DIFF
--- a/src/components/LTextarea/LTextarea.tsx
+++ b/src/components/LTextarea/LTextarea.tsx
@@ -1,0 +1,45 @@
+import { defineComponent } from 'vue';
+import {
+  useValidation,
+  makeValidationEmits,
+  makeValidationProps,
+  UPDATE_MODEL_VALUE,
+} from '@/composables/validation';
+import { useRender } from '@/utils/render';
+
+export const LTextarea = defineComponent({
+  name: 'LTextarea',
+  inheritAttrs: false,
+  props: {
+    ...makeValidationProps<string>(),
+  },
+  emits: {
+    ...makeValidationEmits<string>(),
+  },
+  setup(props, { attrs, emit }) {
+    const validation = useValidation<string>(props);
+
+    const onInput = (event: Event) => {
+      emit(UPDATE_MODEL_VALUE, (event.target as HTMLInputElement).value);
+    };
+
+    useRender(() => (
+      <>
+        <textarea
+          value={props.modelValue}
+          onInput={onInput}
+          onBlur={validation.startValidating}
+          { ...attrs }
+        />
+        { validation.renderError.value && <p>{ validation.error.value }</p> }
+      </>
+    ));
+
+    return {
+      valid: validation.valid,
+      error: validation.error,
+    };
+  },
+});
+
+export type LTextarea = InstanceType<typeof LTextarea>

--- a/src/components/LTextarea/index.ts
+++ b/src/components/LTextarea/index.ts
@@ -1,0 +1,1 @@
+export { LTextarea } from './LTextarea';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './LForm';
 export * from './LInput';
+export * from './LTextarea';


### PR DESCRIPTION
## Description

There is now a `LTextarea` component to be used instead of the default `textarea` HTML component.

## Requirements

None.

## Additional changes

None.
