### PR TITLE
Include grouped checkbox validation

### DIFF
--- a/src/components/LCheckbox/LCheckbox.tsx
+++ b/src/components/LCheckbox/LCheckbox.tsx
@@ -1,0 +1,38 @@
+import { defineComponent, ref } from 'vue';
+import { useRender } from '@/utils/render';
+
+export const LCheckbox = defineComponent({
+  name: 'LCheckbox',
+  inheritAttrs: false,
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    'update:modelValue': (value: boolean) => true,
+  },
+  setup(props, { attrs, emit }) {
+    const content = ref(props.modelValue);
+
+    const onInput = (event: Event) => {
+      content.value = (event.target as HTMLInputElement).checked;
+      emit('update:modelValue', (event.target as HTMLInputElement).checked);
+    };
+
+    useRender(() => (
+      <>
+        <input
+          value={content.value}
+          onInput={onInput}
+          type="checkbox"
+          { ...attrs }
+        />
+      </>
+    ));
+  },
+});
+
+export type LCheckbox = InstanceType<typeof LCheckbox>

--- a/src/components/LCheckbox/LCheckbox.tsx
+++ b/src/components/LCheckbox/LCheckbox.tsx
@@ -1,4 +1,5 @@
 import { defineComponent, ref } from 'vue';
+import { useCheckbox } from '@/composables/checkbox';
 import { useRender } from '@/utils/render';
 
 export const LCheckbox = defineComponent({
@@ -7,7 +8,7 @@ export const LCheckbox = defineComponent({
   props: {
     modelValue: {
       type: Boolean,
-      default: false,
+      default: () => false,
     },
   },
   emits: {
@@ -16,6 +17,8 @@ export const LCheckbox = defineComponent({
   },
   setup(props, { attrs, emit }) {
     const content = ref(props.modelValue);
+
+    useCheckbox(content);
 
     const onInput = (event: Event) => {
       content.value = (event.target as HTMLInputElement).checked;

--- a/src/components/LCheckbox/index.ts
+++ b/src/components/LCheckbox/index.ts
@@ -1,0 +1,1 @@
+export { LCheckbox } from './LCheckbox';

--- a/src/components/LCheckboxGroup/LCheckboxGroup.tsx
+++ b/src/components/LCheckboxGroup/LCheckboxGroup.tsx
@@ -18,9 +18,9 @@ export const LCheckboxGroup = defineComponent({
 
     useRender(() => (
       <>
-        <div>
+        <>
           { slots.default?.() }
-        </div>
+        </>
         { validation.renderError.value && <p>{ validation.error.value }</p> }
       </>
     ));

--- a/src/components/LCheckboxGroup/LCheckboxGroup.tsx
+++ b/src/components/LCheckboxGroup/LCheckboxGroup.tsx
@@ -1,0 +1,35 @@
+import { computed, defineComponent } from 'vue';
+import { createCheckboxGroup } from '@/composables/checkboxGroup';
+import { useValidation, makeValidationProps } from '@/composables/validation';
+import { useRender } from '@/utils/render';
+
+export const LCheckboxGroup = defineComponent({
+  name: 'LCheckboxGroup',
+  inheritAttrs: false,
+  props: {
+    ...makeValidationProps<Array<boolean>>(),
+  },
+  setup(props, { slots }) {
+    const checkboxGroup = createCheckboxGroup();
+
+    const items = computed(() => checkboxGroup.items.value.map((content) => content.value));
+
+    const validation = useValidation<Array<boolean>>(props, items);
+
+    useRender(() => (
+      <>
+        <div>
+          { slots.default?.() }
+        </div>
+        { validation.renderError.value && <p>{ validation.error.value }</p> }
+      </>
+    ));
+
+    return {
+      valid: validation.valid,
+      error: validation.error,
+    };
+  },
+});
+
+export type LCheckboxGroup = InstanceType<typeof LCheckboxGroup>;

--- a/src/components/LCheckboxGroup/index.ts
+++ b/src/components/LCheckboxGroup/index.ts
@@ -1,0 +1,1 @@
+export { LCheckboxGroup } from './LCheckboxGroup';

--- a/src/components/LInput/LInput.tsx
+++ b/src/components/LInput/LInput.tsx
@@ -8,7 +8,7 @@ export const LInput = defineComponent({
   props: {
     modelValue: {
       type: String,
-      default: '',
+      default: () => '',
     },
     ...makeValidationProps<string>(),
   },

--- a/src/components/LInput/LInput.tsx
+++ b/src/components/LInput/LInput.tsx
@@ -32,6 +32,7 @@ export const LInput = defineComponent({
           value={content.value}
           onInput={onInput}
           onBlur={validation.startValidating}
+          type="text"
           { ...attrs }
         />
         { validation.renderError.value && <p>{ validation.error.value }</p> }

--- a/src/components/LTextarea/LTextarea.tsx
+++ b/src/components/LTextarea/LTextarea.tsx
@@ -8,7 +8,7 @@ export const LTextarea = defineComponent({
   props: {
     modelValue: {
       type: String,
-      default: '',
+      default: () => '',
     },
     ...makeValidationProps<string>(),
   },

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './LCheckbox';
+export * from './LCheckboxGroup';
 export * from './LForm';
 export * from './LInput';
 export * from './LTextarea';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './LCheckbox';
 export * from './LForm';
 export * from './LInput';
 export * from './LTextarea';

--- a/src/composables/checkbox.ts
+++ b/src/composables/checkbox.ts
@@ -1,0 +1,19 @@
+import { onBeforeMount, onBeforeUnmount } from 'vue';
+import { useCheckboxGroup } from '@/composables/checkboxGroup';
+import { getUniqueId } from '@/utils/uniqueId';
+
+// Types
+import type { Ref } from 'vue';
+
+export const useCheckbox = (content: Ref<boolean>) => {
+  const checkboxGroup = useCheckboxGroup();
+  const uid = getUniqueId();
+
+  onBeforeMount(() => {
+    checkboxGroup?.register(uid, content);
+  });
+
+  onBeforeUnmount(() => {
+    checkboxGroup?.unregister(uid);
+  });
+};

--- a/src/composables/checkboxGroup.ts
+++ b/src/composables/checkboxGroup.ts
@@ -1,0 +1,44 @@
+import {
+  computed, inject, provide, shallowRef,
+} from 'vue';
+
+// Types
+import type { InjectionKey, Ref } from 'vue';
+
+type IdType = number;
+
+interface Checkbox {
+  id: IdType,
+  value: Ref<boolean>,
+}
+
+export interface CheckboxGroupProvide {
+  register: (
+    id: IdType,
+    value: Ref<boolean>,
+  ) => void,
+  unregister: (
+    id: IdType,
+  ) => void,
+}
+
+export const CheckboxGroupKey: InjectionKey<CheckboxGroupProvide> = Symbol.for('loveform:checkbox-group');
+
+export const createCheckboxGroup = () => {
+  const items = shallowRef<Array<Checkbox>>([]);
+
+  const values = computed(() => items.value.map((checkbox) => checkbox.value));
+
+  provide(CheckboxGroupKey, {
+    register: (id: IdType, value: Ref<boolean>) => {
+      items.value = [...items.value, { id, value }];
+    },
+    unregister: (id: IdType) => {
+      items.value = items.value.filter((item) => item.id !== id);
+    },
+  });
+
+  return { items: values };
+};
+
+export const useCheckboxGroup = () => inject(CheckboxGroupKey, null);

--- a/src/composables/form.ts
+++ b/src/composables/form.ts
@@ -3,9 +3,7 @@ import {
 } from 'vue';
 
 // Types
-import type {
-  ComputedRef, InjectionKey, PropType, Ref,
-} from 'vue';
+import type { InjectionKey, PropType, Ref } from 'vue';
 
 export const SUBMIT = 'submit';
 export const SUBMIT_PROP = 'onSubmit';
@@ -25,13 +23,13 @@ export interface FormProps {
 export interface FormProvide {
   register: (
     id: IdType,
-    valid: ComputedRef<boolean>,
+    valid: Ref<boolean>,
   ) => void,
   unregister: (
     id: IdType,
   ) => void,
   hideErrors: boolean,
-  valid: ComputedRef<boolean>,
+  valid: Ref<boolean>,
 }
 
 export const FormKey: InjectionKey<FormProvide> = Symbol.for('loveform:form');
@@ -62,11 +60,8 @@ export const createForm = (props: FormProps) => {
   });
 
   provide(FormKey, {
-    register: (id: IdType, valid: ComputedRef) => {
-      items.value.push({
-        id,
-        valid,
-      });
+    register: (id: IdType, valid: Ref<boolean>) => {
+      items.value = [...items.value, { id, valid }];
     },
     unregister: (id: IdType) => {
       items.value = items.value.filter((item) => item.id !== id);


### PR DESCRIPTION
## Description

Now there are new components: `LCheckbox` and `LCheckboxGroup`. These components can be used to validate checkboxes, by passing the validations to the `LCheckboxGroup` component and nesting the `LCheckbox` components inside itself.

## Requirements

None.

## Additional changes

None.
